### PR TITLE
feat(fix): remove help arg

### DIFF
--- a/compose-check.sh
+++ b/compose-check.sh
@@ -4,7 +4,7 @@ set -e
 
 if command -v docker-compose &> /dev/null ; then
     COMPOSE=docker-compose
-elif command -v docker &> /dev/null && docker help compose &> /dev/null; then
+elif command -v docker &> /dev/null && docker compose &> /dev/null; then
     COMPOSE="docker compose"
 else
     echo "ERROR: Neither 'docker-compose' or 'docker compose' were found"


### PR DESCRIPTION
In bash files, the word `help` passed as an argument to the `docker compose` command sends the script into error because it is a keyword