### PR TITLE
Update regex to also detect compose.yaml files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Checks that docker-compose files are valid
   language: script
   entry: compose-check.sh
-  files: docker-compose.y[a]{0,1}ml$
+  files: (docker-)?compose.y[a]{0,1}ml$
 
 - id: hadolint
   name: Lint Dockerfiles


### PR DESCRIPTION
According to the new compose specification, compose.yaml is the preferred file name.

See here: https://docs.docker.com/compose/compose-file/03-compose-file/